### PR TITLE
core: add linting rules

### DIFF
--- a/js-src/.eslintrc.json
+++ b/js-src/.eslintrc.json
@@ -1,0 +1,29 @@
+{
+    "env": {
+        "browser": true,
+        "commonjs": true,
+        "es6": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "sourceType": "module"
+    },
+    "rules": {
+        "indent": [
+            "error",
+            4
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "quotes": [
+            "error",
+            "single"
+        ],
+        "semi": [
+            "error",
+            "always"
+        ]
+    }
+}

--- a/js-src/package.json
+++ b/js-src/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "start": "webpack-dev-server --inline --progress --port 8080",
     "test": "karma start",
-    "build": "rimraf dist && webpack --config config/webpack.prod.js --progress --profile --bail"
+    "build": "rimraf dist && webpack --config config/webpack.prod.js --progress --profile --bail",
+    "eslint": "./node_modules/.bin/eslint src/app/ || true"
   },
   "licenses": [
     {
@@ -37,6 +38,7 @@
     "babel-preset-es2015": "^6.6.0",
     "concurrently": "^3.0.0",
     "css-loader": "^0.23.1",
+    "eslint": "^3.11.0",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.5",
     "html-loader": "^0.4.3",


### PR DESCRIPTION
We only have a few simple rules to obey for now. These can be found in the .eslintrc file.
For example, we should indent by 4 spaces, and from looking at most of the code, we will
use single quotes. The command to run the linter is `npm run eslint`.

Resolves #10