### PR TITLE
Core/dist dir

### DIFF
--- a/js-src/package.json
+++ b/js-src/package.json
@@ -5,7 +5,7 @@
     "start": "webpack-dev-server --inline --progress --port 8080",
     "test": "karma start",
     "build": "rimraf dist && webpack --config config/webpack.prod.js --progress --profile --bail ",
-    "dev-build":"rimraf dist && webpack --config config/webpack.dev.js --progress --watch",
+    "dev-build":"rimraf ../python-src/webapp && webpack --config config/webpack.dev.js --progress --watch",
     "eslint": "./node_modules/.bin/eslint src/app/ || true"
   },
   "licenses": [

--- a/js-src/package.json
+++ b/js-src/package.json
@@ -5,7 +5,7 @@
     "start": "webpack-dev-server --inline --progress --port 8080",
     "test": "karma start",
     "build": "rimraf dist && webpack --config config/webpack.prod.js --progress --profile --bail ",
-    "dev-build": "webpack --config config/webpack.dev.js --progress --watch",
+    "dev-build":"rimraf dist && webpack --config config/webpack.dev.js --progress --watch",
     "eslint": "./node_modules/.bin/eslint src/app/ || true"
   },
   "licenses": [

--- a/python-src/webapp
+++ b/python-src/webapp
@@ -1,1 +1,0 @@
-/home/lukas/uni/pintheworld/js-src/dist


### PR DESCRIPTION
The original webapp dir seems to be broken when pulling from origin. We might want to consider if we should ignore the webapp dir. I am not sure if we need it on github in order to deploy to gae.