### PR TITLE
Replace channel with message queue

### DIFF
--- a/docs/lines of code.txt
+++ b/docs/lines of code.txt
@@ -1,8 +1,8 @@
 SourceA/python:
 	- appengine_config.py	7
-	- main.py		25
-	- model.py		27
-	- resources.py		152
+	- main.py		26
+	- model.py		31
+	- resources.py		168
 	- scoring.py		20
 SourceA/javascript:
 	- channel.service.js		16
@@ -10,13 +10,14 @@ SourceA/javascript:
 	- game.service.js		58
 	- guess.service.js		26
 	- highscore.service.js		23
+	- message.service.js		16
 	- player.service.js		37
 	- app.component.js		13
 	- app.module.js 		49
 	- games.component.js		67
 	- highscores.component.js	57
 	- home.component.js		11
-	- map.component.js		202
+	- map.component.js		199
 	- player.component.js		33
 	- room.component.js		46
 SourceA/misc:
@@ -36,7 +37,7 @@ SourceA/misc:
 	- index.html			12
 	- .eslintrc.json		29
 
-Lines in SourceA: 1217
+Lines in SourceA: 1251
 
 SourceB/python:
 SourceB/javascript:
@@ -48,7 +49,7 @@ SourceB/javascript:
 SourceB/misc:
 	- package.json			11
 
-Lines in SourceB: 80
+Lines in SourceB: 34
 
 
-Total lines written by team: 1299
+Total lines written by team: 1285

--- a/js-src/src/app/map.component.js
+++ b/js-src/src/app/map.component.js
@@ -114,7 +114,7 @@ let MapComponent = Component({
                         self.handleIncomingMessage(self, data[i]);
                     }
                 });
-            }, 2000);
+            }, 500);
             // this.channelService.createChannel(player_id).subscribe(function (resp) {
             //     console.log("channel_token:");
             //     console.log(resp.token);

--- a/js-src/src/app/services/message.service.js
+++ b/js-src/src/app/services/message.service.js
@@ -1,0 +1,18 @@
+import {Class} from '@angular/core';
+import {Http} from '@angular/http';
+
+var MessageService = Class({
+    constructor: [Http, function (http) {
+        this.http = http;
+        this.baseUrl = "/api/messages";
+    }],
+    getMessages: function (player_id, game_id) {
+        return this.http.get(this.baseUrl + "/" + player_id + "/" + game_id).map(
+            function (res) {
+                return res.json()
+            }
+        )
+    }
+});
+
+export {MessageService};

--- a/python-src/app.yaml
+++ b/python-src/app.yaml
@@ -1,5 +1,5 @@
 application: pintheworld-146615
-version: 1
+version: 3
 runtime: python27
 api_version: 1
 threadsafe: yes

--- a/python-src/main.py
+++ b/python-src/main.py
@@ -22,6 +22,8 @@ api.add_resource(GameScoreResource, '/highscores/<game_id>')
 
 api.add_resource(ChannelResource, '/channel')
 
+api.add_resource(MessageResource, '/messages/<player_id>/<game_id>')
+
 
 @app.after_request
 def after_request(response):

--- a/python-src/model.py
+++ b/python-src/model.py
@@ -34,7 +34,13 @@ class Game(ndb.Model):
     diff = ndb.IntegerProperty()
 
 
-class GameState():
+class Messages(ndb.Model):
+    player = ndb.KeyProperty(kind=Player)
+    game = ndb.KeyProperty(kind=Game)
+    msg = ndb.StringProperty()
+
+
+class GameState:
     waitingForPlayers = 'waitingForPlayers'
     running = 'running'
     done = 'done'


### PR DESCRIPTION
the problem in production was, that we cannot receive any messages pushed from the server, we can create a channel, but afterwards not subscribe to it - this means we do not get guesses from other players and therefore are waiting for the other player forever.. i played with the channel API a bit and could not get it working in production, only locally - i then also tried some official tutorial apps and they don't work either (probably because channel api is deprecated an will be shut down in a year, but the documentation says its still supported, they suggest to switch to firebase as an alternative but that is outside of GAE and im not sure if we are allowed to use it) long story short, what i did now is implement a message queue on the server we push the channel messages to, which is then polled by the client..